### PR TITLE
Improve markdown rendering under tailwind

### DIFF
--- a/assets/css/markdown-dark.scss
+++ b/assets/css/markdown-dark.scss
@@ -15,7 +15,7 @@
     }
 
     blockquote {
-      color: #8B949EFF;
+      color: #a6b1bd;
     }
 
     code {

--- a/assets/css/markdown-dark.scss
+++ b/assets/css/markdown-dark.scss
@@ -1,0 +1,44 @@
+.dark {
+  .markdown {
+
+    table thead th {
+      color: #e0e0e0;
+    }
+
+    table tr:nth-child(2n) {
+      background-color: #323235;
+    }
+
+    table tr > td,
+    .page-rendered table tr > th {
+      border-color: #e0e0e0;
+    }
+
+    blockquote {
+      color: #8B949EFF;
+    }
+
+    code {
+      background-color: #37393b;
+    }
+
+    pre {
+      background-color: #37393b;
+      code {
+        background-color: transparent;
+      }
+    }
+
+    h1,
+    h2 {
+      border-bottom-color: #57595e;
+    }
+  }
+}
+
+// Active tailwind overrides specific to markdown.
+
+// Table header colour
+.dark .prose.markdown ol > li:before {
+  color: #e0e0e0;
+}

--- a/assets/css/markdown-light.scss
+++ b/assets/css/markdown-light.scss
@@ -1,0 +1,40 @@
+.light {
+  .markdown {
+
+    table tr:nth-child(2n) {
+      background-color: #f5f5f5;
+    }
+
+    table tr > td, .page-rendered table tr > th {
+      border-color: #e0e0e0;
+    }
+
+    blockquote {
+      color: #57606a;
+    }
+
+    code {
+      background-color: #dfe0e1;
+    }
+
+    pre {
+      background-color: #dfe0e1;
+      code {
+        background-color: transparent;
+      }
+    }
+
+    code {
+      color: black // Specific colour override for code, tailwind does not properly theme pre's and their content.
+    }
+
+    a code {
+      color: #42a5f5;
+    }
+
+    h1,
+    h2 {
+      border-bottom-color: #e0e0e0;
+    }
+  }
+}

--- a/assets/css/markdown.scss
+++ b/assets/css/markdown.scss
@@ -81,6 +81,14 @@
   blockquote {
     margin: 0;
   }
+
+  ul, ol {
+    padding-inline-start: 1rem;
+  }
+
+  p + ul, p + ol {
+    margin-top: -10px;
+  }
 }
 
 // Active tailwind overrides specific to markdown.

--- a/assets/css/markdown.scss
+++ b/assets/css/markdown.scss
@@ -1,23 +1,9 @@
-.dark {
-  .markdown {
-    table tr:nth-child(2n) {
-      background-color: #323235;
-    }
-
-    code {
-      //background-color: #343e47;
-      //color: white;
-    }
-  }
-}
+@import "markdown-light";
+@import "markdown-dark";
 
 .markdown {
   table tr > th {
     padding: 5px;
-  }
-
-  table tr:nth-child(2n) {
-    background-color: #f5f5f5;
   }
 
   h1,
@@ -35,8 +21,8 @@
 
   table tr > td,
   .page-rendered table tr > th {
+    border: 1px solid;
     padding: 10px;
-    border: 1px solid #e0e0e0;
   }
 
   code::before,
@@ -45,29 +31,19 @@
   }
 
   code {
-    background-color: #d5d5d5;
-    color: black;
     padding: 0.1em 0.3em;
     font-size: 80%;
     border-radius: 3px;
   }
 
-  a code {
-    color: #42a5f5;
-
-    &:hover {
-      text-decoration: underline;
-    }
+  a code &:hover {
+    text-decoration: underline;
   }
 
   h1,
   h2 {
-    border-bottom: 1px solid #e0e0e0;
-    padding-bottom: 2px;
-
-    .dark & {
-      border-bottom: 1px solid #5c5c5c;
-    }
+    border-bottom: 1px solid;
+    padding-bottom: 5px;
   }
 
   .headeranchor {
@@ -101,4 +77,25 @@
       margin: 0;
     }
   }
+
+  blockquote {
+    margin: 0;
+  }
+}
+
+// Active tailwind overrides specific to markdown.
+
+// Padding on first table row element
+.prose.markdown table tbody td:first-child {
+  padding-left: 10px;
+}
+
+// Padding on table header
+.prose.markdown table thead th:first-child {
+  padding-left: 5px;
+}
+
+// Adjust code font weight
+.prose.markdown code {
+  font-weight: 400;
 }


### PR DESCRIPTION
The markdown css stying is heavily subjected to tailwinds
typography plugin. While this in general works great, some specific
stylings added by tailwind however actively work against the desired
look of markdown in hangar.

This commit actively removes some of the major concerns, such as lost
padding on values in a tables first collum.

Beyond that, this commit also extracts any form of colouring from the
main markdown styling and extracts any specifics into a light and dark
theme, avoiding a parent-child relation between the light and dark
theme.

# Notes
This is obviously very much based on opinion. I am open to implement any changes requested, this is simply my feeling of proper markdown rendering.

# Comparison

## Table - Light mode

### Old
![OLD](https://user-images.githubusercontent.com/32834385/179833247-829e3787-424e-4212-ab88-741a55252577.png)

### New
![image](https://user-images.githubusercontent.com/32834385/179833361-5cbaa8fe-95d1-4fef-a838-acf658adbc20.png)

## Table - Dark Mode

### Old
![image](https://user-images.githubusercontent.com/32834385/179833494-f28bf570-a710-44b8-954b-811fa099d562.png)

### New
![image](https://user-images.githubusercontent.com/32834385/179833534-ffb11b5d-e3f2-4134-8f6a-2bb79095ad6c.png)

## Blockquotes - Light mode

### Old
![image](https://user-images.githubusercontent.com/32834385/179833606-bb039cf0-5aaa-4d8a-9626-dbd1cb1f8f0b.png)

### New
![image](https://user-images.githubusercontent.com/32834385/179833654-a948f36f-f733-4a82-a5cf-5bdfa492e59c.png)

## Blockquotes - Dark Mode

### Old
![image](https://user-images.githubusercontent.com/32834385/179833709-8510fa0d-da99-4ad8-b306-3128cbd27f5d.png)

### New
![image](https://user-images.githubusercontent.com/32834385/179833730-45167351-660a-4ad9-90af-3c7903123e1f.png)

## Lists - Dark Mode

### Old
![image](https://user-images.githubusercontent.com/32834385/179834073-feb5e3e5-fadf-4a33-a1e2-0a43a8a4f199.png)

### New
![image](https://user-images.githubusercontent.com/32834385/179834101-2d619fa6-7c72-412b-a92f-c04964598abc.png)

## Code - Light Mode

### Old
![image](https://user-images.githubusercontent.com/32834385/179834165-a8162dc0-54f6-4edb-a4ff-5ac447f5d432.png)

### New
![image](https://user-images.githubusercontent.com/32834385/179834176-8f5294a7-5b97-4ed6-ad95-976266bea468.png)

## Code - Dark Mode

### Old
![image](https://user-images.githubusercontent.com/32834385/179834206-0ba96039-10d7-442d-bd17-51f977be51ff.png)

### New
![image](https://user-images.githubusercontent.com/32834385/179834231-aa3956d1-3cd2-44b8-9010-16582087de11.png)
