### PR TITLE
Call Router#back when aborting Steps component

### DIFF
--- a/components/design/Steps.vue
+++ b/components/design/Steps.vue
@@ -6,7 +6,9 @@ import { useSettingsStore } from "~/store/settings";
 import Button from "~/lib/components/design/Button.vue";
 import { useI18n } from "vue-i18n";
 import { useVuelidate } from "@vuelidate/core";
+import { useRouter } from "vue-router";
 
+const router = useRouter();
 const settings = useSettingsStore();
 const i18n = useI18n();
 
@@ -37,6 +39,11 @@ const showNext = computed(() => (activeStep.value?.showNext ? activeStep.value?.
 async function back() {
   if (disableBack.value) return;
   if (activeStep.value?.beforeBack && !(await activeStep.value?.beforeBack())) return;
+
+  if (activeStepIndex.value === 1) {
+    router.back();
+    return;
+  }
 
   internalValue.value = props.steps[activeStepIndex.value - 2].value;
 }


### PR DESCRIPTION
When the Steps component attempts to step one step back on its first
step, it attempts to lookup a negative-indexed step causing a client
error.

To fix this, by default, the Steps component calls Router#back when
attempting to step back on the first step element.
This behaviour can be overwritten by defining a custom beforeBack
handler on the specific step, allowing individual components to inject
their own abort logic if wanted.