### PR TITLE
Add enter icon to the end of input tag component

### DIFF
--- a/components/ui/InputTag.vue
+++ b/components/ui/InputTag.vue
@@ -112,16 +112,14 @@ const filteredOptions = computed(() => {
           </option>
         </datalist>
       </template>
-      <input
+      <div
         v-else
-        v-model="tag"
-        type="text"
-        class="pointer-events-auto flex-grow !bg-gray-100 rounded-xl px-2 dark:(!bg-gray-500 text-white)"
+        class="pointer-events-auto relative flex flex-column items-center flex-grow !bg-gray-100 rounded-xl px-2 dark:(!bg-gray-500 text-white)"
         :class="slotProps.class"
-        :maxlength="tagMaxlength"
-        @keydown.enter="add"
-        @blur="v.$touch()"
-      />
+      >
+        <IconMdiSubdirectoryArrowLeft class="absolute right-2"> </IconMdiSubdirectoryArrowLeft>
+        <input v-model="tag" type="text" :class="slotProps.class" :maxlength="tagMaxlength" @keydown.enter="add" @blur="v.$touch()" />
+      </div>
     </div>
   </InputWrapper>
 </template>


### PR DESCRIPTION
To make the proper usage of an input tag easier to understand,
specifically that one has to press enter for each entered entry, this
commit adds an icon indicating pressing enter to the end of the input
tag if no options are provided to the input tag.

# Comparison

## Old
![image](https://user-images.githubusercontent.com/32834385/181841553-79baa5cc-ddd4-4ac1-bc8d-9084e0d8c24a.png)
![image](https://user-images.githubusercontent.com/32834385/181841592-7b2c1fb1-7d01-42b5-a038-34ffa4132600.png)

## New
![image](https://user-images.githubusercontent.com/32834385/181841768-01d80ca1-a749-4203-950e-e97edb212591.png)
![image](https://user-images.githubusercontent.com/32834385/181841642-940f4069-7445-4cb0-808a-06874f0e66a3.png)